### PR TITLE
create an alternative to bootstrapping the sample DB isntead of tryin…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ bin
 build.xml
 .DS_Store
 m2e-wtp
-
+*.iml
+.idea
 # btm transaction
 *.tlog
 ObjectStore

--- a/samples/rdbms/Readme.md
+++ b/samples/rdbms/Readme.md
@@ -7,7 +7,51 @@ Running a psql in Docker:
 We set the default username/password when we start up the postgres database. We also map the default postgres port on `5432` to our localhost on port `5432`. If you're running in a VM (ie, if you're running on Windows or Mac), you'll need to figure out a way to port forward your localhost to the VM that's running your docker daemon (ie, the application assumes the postgres is running on localhost). 
  
 We can init the database with a simple script (note, we're mounting in the script so adjust the mount location to your location -- in this project it's in the `./scripts` folder)
- 
-> docker run -it --rm -v /Users/ceposta/dev/idea-workspace/teiid/teiid-spring-boot/samples/rdbms/scripts:/scripts --link some-postgres:postgres postgres:9.5 psql -h postgres -U rareddy -f /scripts/example.sql
+
+To do that, we can have two options: 
+
+1. Build the Docker image for the `psql` client that includes the sample setup scripts
+2. Use an already built image to do the same as `1`
+
+#### Build the docker image yourself
+
+From the `./scripts` folder, run the following to build the docker image:
+
+> docker build -t postgres-cli:latest .
+
+#### Use an existing psql image with the scripts built in:
+
+> docker pull ceposta/postgres-cli:latest
+
+Then you can run it and init the database like this (note the docker image name -- should be ceposta/postgres-cli:latest if pulling it down instead of building it):
+
+> docker run -it --rm -e PGPASSWORD=mm --link some-postgres:postgres postgres-cli -h postgres -U rareddy -f /scripts/example.sql
+
+Now we can log into the `psql` terminal and verify our tables were set up correctly:
+
+> docker run -it --rm -e PGPASSWORD=mm --link some-postgres:postgres postgres-cli -h postgres -U rareddy 
+
+```
+psql (9.5.9)
+Type "help" for help.
+
+rareddy=# \l
+                                 List of databases
+   Name    |  Owner   | Encoding |  Collate   |   Ctype    |   Access privileges   
+-----------+----------+----------+------------+------------+-----------------------
+ customer  | rareddy  | UTF8     | en_US.utf8 | en_US.utf8 | 
+ postgres  | postgres | UTF8     | en_US.utf8 | en_US.utf8 | 
+ rareddy   | postgres | UTF8     | en_US.utf8 | en_US.utf8 | 
+ template0 | postgres | UTF8     | en_US.utf8 | en_US.utf8 | =c/postgres          +
+           |          |          |            |            | postgres=CTc/postgres
+ template1 | postgres | UTF8     | en_US.utf8 | en_US.utf8 | =c/postgres          +
+           |          |          |            |            | postgres=CTc/postgres
+ test      | rareddy  | UTF8     | en_US.utf8 | en_US.utf8 | 
+(6 rows)
+
+rareddy=# 
+```
+
+You can see our `test` and `customer` tables are there!
 
 

--- a/samples/rdbms/scripts/Dockerfile
+++ b/samples/rdbms/scripts/Dockerfile
@@ -1,0 +1,7 @@
+FROM postgres:9.5
+LABEL maintainer="https://lists.jboss.org/mailman/listinfo/teiid-users"
+
+RUN mkdir -p /scripts
+COPY example.sql /scripts
+
+ENTRYPOINT ["psql",""]


### PR DESCRIPTION
…g to mount in the set up scripts


This was the best I could do for now; `docker run` seems pretty finicky trying to pipe in content from stdin and into psql   