### PR TITLE
removed odata4 context path as a default for spring boot apps

### DIFF
--- a/starter/src/main/resources/teiid.properties
+++ b/starter/src/main/resources/teiid.properties
@@ -1,5 +1,2 @@
 spring.jpa.database-platform=org.teiid.dialect.TeiidDialect
 spring.datasource.teiid.url=jdbc:teiid:spring;useCallingThread=true;autoFailover=true;waitForLoad=5000;autoCommitTxn=OFF
-server.contextPath = /odata4
-
-


### PR DESCRIPTION
this was defaulting to a context path of `/odata4` for all my spring boot endpoints when i included this `teiid-spring-boot-starter`  .. we should just default to "/" like spring boot does OOTB and let users explicitly configure for this if they desire. Thoughts?